### PR TITLE
136 feat login native rn

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -5,7 +5,7 @@ export default {
     version: '1.0.0',
     orientation: 'portrait',
     icon: './assets/images/icon.png',
-    scheme: 'myapp',
+    scheme: 'frameit',
     userInterfaceStyle: 'automatic',
     newArchEnabled: true,
     ios: {
@@ -39,6 +39,7 @@ export default {
     },
     extra: {
       webviewUrl: process.env.WEBVIEW_URL,
+      apiUrl: process.env.API_URL,
     },
   },
 };

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,20 +1,43 @@
-import { handleWebViewMessage } from '@/utils/messageHandlers';
+import { useMessageHandlers } from '@/hooks/useMessageHandlers';
 import Constants from 'expo-constants';
+import { useEffect, useRef } from 'react';
 import { SafeAreaView, StyleSheet } from 'react-native';
 import { WebView, WebViewMessageEvent } from 'react-native-webview';
 
 export default function HomeScreen() {
+  const webViewUrl = Constants.expoConfig?.extra?.webviewUrl;
+  const webviewRef = useRef<WebView>(null);
+
+  const { handleWebViewMessage, isWebReady, authData, setAuthData } =
+    useMessageHandlers();
   const handleMessage = async (event: WebViewMessageEvent) => {
     const data = JSON.parse(event.nativeEvent.data);
     await handleWebViewMessage(data);
   };
-  const webViewUrl = Constants.expoConfig?.extra?.webviewUrl;
+
+  useEffect(() => {
+    if (isWebReady && authData && webviewRef.current) {
+      const jsCode = `
+      (async function () {
+        if (typeof window.receiveAuthData === 'function') {
+          await window.receiveAuthData(${JSON.stringify(authData)});
+        } else {
+          alert('window.receiveAuthData is not defined');
+        }
+      })();
+      true;
+    `;
+      webviewRef.current.injectJavaScript(jsCode);
+      setAuthData(null);
+    }
+  }, [authData, isWebReady, webviewRef]);
 
   if (!webViewUrl) return;
 
   return (
     <SafeAreaView style={styles.webviewContainer}>
       <WebView
+        ref={webviewRef}
         source={{ uri: webViewUrl }}
         style={styles.webview}
         onMessage={handleMessage}

--- a/hooks/useMessageHandlers.ts
+++ b/hooks/useMessageHandlers.ts
@@ -1,0 +1,47 @@
+import {
+  login,
+  openInAppBrowser,
+  saveToken,
+  TMessage,
+  tokenExpired,
+} from '@/utils/messageHandlers';
+import { useState } from 'react';
+
+export const useMessageHandlers = () => {
+  const [isWebReady, setIsWebReady] = useState(false);
+  const [authData, setAuthData] = useState<any>(null);
+
+  const handleWebViewMessage = async (data: TMessage) => {
+    try {
+      switch (data.type) {
+        case 'OPEN_IN_APP_BROWSER':
+          openInAppBrowser(data.payload.url);
+          break;
+
+        case 'SAVE_TOKEN':
+          await saveToken(data.payload.token);
+          break;
+
+        case 'TOKEN_EXPIRED':
+          await tokenExpired();
+          break;
+
+        case 'AUTH_CODE':
+          const loginData = await login(data.payload);
+          setAuthData(loginData);
+          break;
+
+        case 'READY':
+          setIsWebReady(true);
+          break;
+
+        default:
+          console.warn('알 수 없는 메시지 타입');
+      }
+    } catch (error) {
+      console.error('메시지 파싱 오류:', error);
+    }
+  };
+
+  return { handleWebViewMessage, isWebReady, authData, setAuthData };
+};

--- a/service/auth-service.ts
+++ b/service/auth-service.ts
@@ -1,0 +1,26 @@
+import Constants from 'expo-constants';
+
+export const sendCodeToBackend = async (
+  code: string,
+  state: string
+): Promise<any> => {
+  try {
+    const response = await fetch(
+      `${Constants.expoConfig?.extra?.apiUrl}/login/${state}?code=${code}&redirect_uri=${Constants.expoConfig?.extra?.webviewUrl}/login`,
+      {
+        method: 'GET',
+        cache: 'no-store',
+      }
+    );
+    if (!response.ok) {
+      const errorData = await response.json();
+      throw new Error(
+        `서버 오류: ${response.status}, ${JSON.stringify(errorData)}`
+      );
+    }
+
+    return response.json();
+  } catch (e) {
+    console.log(e);
+  }
+};

--- a/utils/messageHandlers.ts
+++ b/utils/messageHandlers.ts
@@ -1,10 +1,13 @@
+import { sendCodeToBackend } from '@/service/auth-service';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { Alert, Linking } from 'react-native';
 
-type TMessage =
+import { Alert, Linking } from 'react-native';
+export type TMessage =
   | { type: 'OPEN_IN_APP_BROWSER'; payload: { url: string } }
   | { type: 'SAVE_TOKEN'; payload: { token: string } }
-  | { type: 'TOKEN_EXPIRED' };
+  | { type: 'AUTH_CODE'; payload: { code: string } }
+  | { type: 'TOKEN_EXPIRED' }
+  | { type: 'READY' };
 
 // 인앱 브라우저 열기
 export const openInAppBrowser = (url: string) => {
@@ -31,26 +34,31 @@ export const tokenExpired = async () => {
   // TODO: refresh token 처리
 };
 
-// 메시지 핸들러 (메시지 타입에 따른 처리)
-export const handleWebViewMessage = async (data: TMessage) => {
+interface AuthMessage {
+  type: string;
+  payload: {
+    code: string;
+    state?: string;
+  };
+}
+
+export const login = async (payload: AuthMessage['payload']) => {
   try {
-    switch (data.type) {
-      case 'OPEN_IN_APP_BROWSER':
-        openInAppBrowser(data.payload.url);
-        break;
+    if (payload.code && payload.state) {
+      const authCode = payload.code;
+      const state = payload.state;
 
-      case 'SAVE_TOKEN':
-        await saveToken(data.payload.token);
-        break;
+      try {
+        const resData = await sendCodeToBackend(authCode, state);
 
-      case 'TOKEN_EXPIRED':
-        await tokenExpired();
-        break;
-
-      default:
-        console.warn('알 수 없는 메시지 타입');
+        await AsyncStorage.setItem('refreshToken', resData.refreshToken);
+        return resData;
+      } catch (error) {
+        console.error('인증 중 에러:', error);
+        Alert.alert('로그인 오류', '서버와 통신 중 문제가 발생했습니다.');
+      }
     }
   } catch (error) {
-    console.error('메시지 파싱 오류:', error);
+    console.error('Error parsing incoming message:', error);
   }
 };


### PR DESCRIPTION
> ### PR 제목은 핵심 변경 사항을 요약해주세요.

---

## 🙋‍ Summary (요약)

- 웹뷰에서 로그인 시 리액트 네이티브 앱으로 auth code를  전송하고, 앱에서 해당 code로 프레이밋 서버에 토큰을 요청합니다. 앱에는 `refreshToken`를 저장하고, 웹뷰에 `accessToken`를 전달합니다.
- `refreshToken`을 탈취당하지 않기 위해 네이티브 내에서 프레이밋 서버로 토큰을 요청했습니다.

## 🤔 Describe your Change (변경사항)

- 메세지 핸들러 커스텀 훅 추가 -> `isWebReady`, `authData` 상태 추가

## 🔗 Issue number and link (참고)

[front 레포]
- [#136](https://github.com/Frame-It/frame-it-front/issues/136)
- [#147](https://github.com/Frame-It/frame-it-front/pull/147)

